### PR TITLE
added getSeason method

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,19 @@ Get a list of available providers.
 
 Get a list of available genres.
 
+#### jw.getSeasons(season_id)
+
+- `season_id` [\<integer>] The ID of the Season. Can be obtaines from the getTitle('show', {ID of the TV show})
+- Returns: [\<Promise>] A promise that resolves to the response
+
+Get a list of season details and lists all episodes for a given TV show's season
+
 #### jw.getEpisodes(show_id)
 
 - `show_id` [\<integer>] The ID of the TV show
 - Returns: [\<Promise>] A promise that resolves to the response
 
-Get a list of episodes for a given TV show
+Get a list of episodes for a given TV show. For a complete list of episodes for a season, use getSeasons above.
 
 #### jw.getTitle(content_type, title_id)
 

--- a/index.js
+++ b/index.js
@@ -151,6 +151,13 @@ class JustWatch
 		return await this.request('GET', '/genres/locale/'+locale);
 	}
 
+	async getSeason(season_id)
+	{
+		season_id = encodeURIComponent(season_id);
+		var locale = encodeURIComponent(this._options.locale);
+		return await this.request('GET', '/titles/show_season/' + season_id + '/locale/' + locale);
+	}
+
 	async getEpisodes(show_id)
 	{
 		show_id = encodeURIComponent(show_id);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,0 @@
-{
-  "name": "justwatch-api",
-  "version": "1.0.3",
-  "lockfileVersion": 1
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "justwatch-api",
+  "version": "1.0.3",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "justwatch-api",
   "repository": {
-	  "type": "git",
-	  "url": "https://github.com/lufinkey/node-justwatch-api"
+    "type": "git",
+    "url": "https://github.com/lufinkey/node-justwatch-api"
   },
   "version": "1.0.3",
   "description": "access the justwatch.com API",


### PR DESCRIPTION
**Reference Issue #2**
#### jw.getSeasons(season_id)

- `season_id` [\<integer>] The ID of the Season. Can be obtaines from the getTitle('show', {ID of the TV show})
- Returns: [\<Promise>] A promise that resolves to the response

Get a list of season details and lists **all** episodes for a given TV show's season.