### PR TITLE
updated path to new justwatch api path

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ class JustWatch
 			var reqData = {
 				protocol: 'https:',
 				hostname: API_DOMAIN,
-				path: endpoint,
+				path: '/content' + endpoint,
 				method: method,
 				headers: {}
 			};


### PR DESCRIPTION
It seems that justwatch has changed their path to include /content. I added it to the request logic to get the api working again.